### PR TITLE
Add support for server and client model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ build:
 
 run_tests:
 	@                                                                        \
-	ETSI_014_TEST_SUITE_BASE_URL=https://localhost:8443/api/v1/keys          \
+	ETSI_014_TEST_SUITE_BASE_SERVER_URL=https://localhost:8443/api/v1/keys   \
+	ETSI_014_TEST_SUITE_BASE_CLIENT_URL=https://localhost:8443/api/v1/keys   \
 	ETSI_014_TEST_SUITE_TLS_ROOT_CRT=$(ROOT_DIR)/certs/root.crt              \
 	ETSI_014_TEST_SUITE_MASTER_SAE_ID=sae_001                                \
 	ETSI_014_TEST_SUITE_TLS_MASTER_SAE_CERT=$(ROOT_DIR)/certs/sae_001.pem    \
@@ -24,7 +25,8 @@ run_tests:
 
 run_functional_tests:
 	@                                                                        \
-	ETSI_014_TEST_SUITE_BASE_URL=https://localhost:8443/api/v1/keys          \
+	ETSI_014_TEST_SUITE_BASE_SERVER_URL=https://localhost:8443/api/v1/keys   \
+	ETSI_014_TEST_SUITE_BASE_CLIENT_URL=https://localhost:8443/api/v1/keys   \
 	ETSI_014_TEST_SUITE_TLS_ROOT_CRT=$(ROOT_DIR)/certs/root.crt              \
 	ETSI_014_TEST_SUITE_MASTER_SAE_ID=sae_001                                \
 	ETSI_014_TEST_SUITE_TLS_MASTER_SAE_CERT=$(ROOT_DIR)/certs/sae_001.pem    \
@@ -36,7 +38,8 @@ run_functional_tests:
 
 run_validation_tests:
 	@                                                                        \
-	ETSI_014_TEST_SUITE_BASE_URL=https://localhost:8443/api/v1/keys          \
+	ETSI_014_TEST_SUITE_BASE_SERVER_URL=https://localhost:8443/api/v1/keys   \
+	ETSI_014_TEST_SUITE_BASE_CLIENT_URL=https://localhost:8443/api/v1/keys   \
 	ETSI_014_TEST_SUITE_TLS_ROOT_CRT=$(ROOT_DIR)/certs/root.crt              \
 	ETSI_014_TEST_SUITE_MASTER_SAE_ID=sae_001                                \
 	ETSI_014_TEST_SUITE_TLS_MASTER_SAE_CERT=$(ROOT_DIR)/certs/sae_001.pem    \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ tests.
 
 | Environment variable                     | Description                                                            |
 |------------------------------------------|------------------------------------------------------------------------|
-ETSI_014_TEST_SUITE_BASE_URL               | Base URL of the server to test.                                        |
+ETSI_014_TEST_SUITE_BASE_SERVER_URL        | Base URL of the server to test.                                        |
+ETSI_014_TEST_SUITE_BASE_CLIENT_URL        | Base URL of the client to test.                                        |
 ETSI_014_TEST_SUITE_TLS_ROOT_CRT           | Path to the root certificate.                                          |
 ETSI_014_TEST_SUITE_MASTER_SAE_ID          | Name of the master SAE ID.                                             |
 ETSI_014_TEST_SUITE_TLS_MASTER_SAE_CERT    | Path to the certificate to associate with the master SAE ID.           |

--- a/tests/common/config.rs
+++ b/tests/common/config.rs
@@ -3,7 +3,8 @@
 
 use std::env;
 
-static ENV_BASE_URL: &str = "ETSI_014_TEST_SUITE_BASE_URL";
+static ENV_BASE_SERVER_URL: &str = "ETSI_014_TEST_SUITE_BASE_SERVER_URL";
+static ENV_BASE_CLIENT_URL: &str = "ETSI_014_TEST_SUITE_BASE_CLIENT_URL";
 static ENV_TLS_ROOT_CRT: &str = "ETSI_014_TEST_SUITE_TLS_ROOT_CRT";
 static ENV_MASTER_SAE_ID: &str = "ETSI_014_TEST_SUITE_MASTER_SAE_ID";
 static ENV_TLS_MASTER_SAE_CERT: &str =
@@ -15,7 +16,8 @@ static ENV_TLS_ADD_SLAVE_SAE_CERT: &str =
 static ENV_ADD_SLAVE_SAE_ID: &str = "ETSI_014_TEST_SUITE_ADD_SLAVE_SAE_ID";
 
 pub struct Config {
-    pub base_url: String,
+    pub base_server_url: String,
+    pub base_client_url: String,
     pub root_crt: String,
     pub master_sae_id: String,
     pub master_sae_crt: String,
@@ -28,7 +30,8 @@ pub struct Config {
 impl Config {
     pub fn new() -> Self {
         Self {
-            base_url: Self::extract_string_value(ENV_BASE_URL),
+            base_server_url: Self::extract_string_value(ENV_BASE_SERVER_URL),
+            base_client_url: Self::extract_string_value(ENV_BASE_CLIENT_URL),
             root_crt: Self::extract_string_value(ENV_TLS_ROOT_CRT),
             master_sae_id: Self::extract_string_value(ENV_MASTER_SAE_ID),
             master_sae_crt: Self::extract_string_value(ENV_TLS_MASTER_SAE_CERT),

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -18,10 +18,14 @@ use test_case::test_case;
 #[test_case(Method::GET; "Using GET")]
 #[test_case(Method::POST; "Using POST")]
 fn successful_key_request_and_retrieval(request_method: Method) {
-    let enc_keys_url =
-        format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
-    let dec_keys_url =
-        format!("{}/{}/dec_keys", CONFIG.base_url, CONFIG.master_sae_id);
+    let enc_keys_url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
+    let dec_keys_url = format!(
+        "{}/{}/dec_keys",
+        CONFIG.base_client_url, CONFIG.master_sae_id
+    );
     let master_client = common::build_client(&CONFIG.master_sae_crt);
     let slave_client = common::build_client(&CONFIG.slave_sae_crt);
 
@@ -87,10 +91,14 @@ fn successful_key_request_and_retrieval(request_method: Method) {
 #[test_case(Method::GET; "Using GET")]
 #[test_case(Method::POST; "Using POST")]
 fn unauthorized_access(request_method: Method) {
-    let enc_keys_url =
-        format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
-    let dec_keys_url =
-        format!("{}/{}/dec_keys", CONFIG.base_url, CONFIG.master_sae_id);
+    let enc_keys_url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
+    let dec_keys_url = format!(
+        "{}/{}/dec_keys",
+        CONFIG.base_client_url, CONFIG.master_sae_id
+    );
     let master_client = common::build_client(&CONFIG.master_sae_crt);
     let unauthorized_client = common::build_client(&CONFIG.add_slave_sae_crt);
 
@@ -143,10 +151,14 @@ fn unauthorized_access(request_method: Method) {
 #[test_case(Method::GET; "Using GET")]
 #[test_case(Method::POST; "Using POST")]
 fn additional_slave_sae_ids(request_method: Method) {
-    let enc_keys_url =
-        format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
-    let dec_keys_url =
-        format!("{}/{}/dec_keys", CONFIG.base_url, CONFIG.master_sae_id);
+    let enc_keys_url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
+    let dec_keys_url = format!(
+        "{}/{}/dec_keys",
+        CONFIG.base_client_url, CONFIG.master_sae_id
+    );
     let master_client = common::build_client(&CONFIG.master_sae_crt);
     let additional_slave_client =
         common::build_client(&CONFIG.add_slave_sae_crt);
@@ -200,9 +212,11 @@ fn additional_slave_sae_ids(request_method: Method) {
 #[test_case(Method::POST; "Using POST")]
 fn default_values_match_status_reply(request_method: Method) {
     let status_url =
-        format!("{}/{}/status", CONFIG.base_url, CONFIG.slave_sae_id);
-    let enc_keys_url =
-        format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
+        format!("{}/{}/status", CONFIG.base_server_url, CONFIG.slave_sae_id);
+    let enc_keys_url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
     let client = common::build_client(&CONFIG.master_sae_crt);
 
     // Request status

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -21,7 +21,10 @@ use uuid::Uuid;
 #[test_case("abc01"; "Alphanumeric key size")]
 fn key_size(key_size: &str) {
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let url = format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
+    let url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
     let mut responses: Vec<Response> = Vec::new();
 
     responses
@@ -56,7 +59,10 @@ fn key_size(key_size: &str) {
 #[test_case("abc01"; "Alphanumeric number of requested keys")]
 fn num_keys(num_keys: &str) {
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let url = format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
+    let url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
     let mut responses: Vec<Response> = Vec::new();
 
     responses
@@ -93,7 +99,10 @@ fn num_keys(num_keys: &str) {
 #[test_case(vec![]; "Empty SAE ID list")]
 fn additional_sae_ids(additional_slave_sae_ids: std::vec::Vec<&str>) {
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let url = format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
+    let url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
 
     let response = client
         .post(url)
@@ -121,8 +130,8 @@ fn empty_sae_id_in_path() {
     // The test can be updated such that it first gets a key and then calls the
     // endpoint, but that is more of a functional test, than validation test.
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let enc_keys_url = format!("{}/ /enc_keys", CONFIG.base_url);
-    let dec_keys_url = format!("{}/ /dec_keys", CONFIG.base_url);
+    let enc_keys_url = format!("{}/ /enc_keys", CONFIG.base_server_url);
+    let dec_keys_url = format!("{}/ /dec_keys", CONFIG.base_client_url);
     let sample_key_id = Uuid::new_v4();
     let mut responses: Vec<Response> = Vec::new();
 
@@ -170,10 +179,14 @@ fn identical_sae_ids() {
     // The test can be updated such that it first gets a key and then calls the
     // endpoint, but that is more of a functional test, than validation test.
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let enc_keys_url =
-        format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.master_sae_id);
-    let dec_keys_url =
-        format!("{}/{}/dec_keys", CONFIG.base_url, CONFIG.master_sae_id);
+    let enc_keys_url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.master_sae_id
+    );
+    let dec_keys_url = format!(
+        "{}/{}/dec_keys",
+        CONFIG.base_client_url, CONFIG.master_sae_id
+    );
     let sample_key_id = Uuid::new_v4();
     let mut responses: Vec<Response> = Vec::new();
 
@@ -216,7 +229,10 @@ fn identical_sae_ids() {
 #[test]
 fn key_id() {
     let client = common::build_client(&CONFIG.slave_sae_crt);
-    let url = format!("{}/{}/dec_keys", CONFIG.base_url, CONFIG.master_sae_id);
+    let url = format!(
+        "{}/{}/dec_keys",
+        CONFIG.base_client_url, CONFIG.master_sae_id
+    );
     let invalid_key_id = "non-uuid";
     let mut responses: Vec<Response> = Vec::new();
 
@@ -254,7 +270,10 @@ fn key_id() {
 #[test_case(Method::POST; "Using POST")]
 fn num_keys_requested_equals_returned(request_method: Method) {
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let url = format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
+    let url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
     let num_keys = 5;
 
     // Request a key
@@ -290,7 +309,10 @@ fn num_keys_requested_equals_returned(request_method: Method) {
 #[test_case(Method::POST; "Using POST")]
 fn key_body(request_method: Method) {
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let url = format!("{}/{}/enc_keys", CONFIG.base_url, CONFIG.slave_sae_id);
+    let url = format!(
+        "{}/{}/enc_keys",
+        CONFIG.base_server_url, CONFIG.slave_sae_id
+    );
     let num_keys = 3;
     let key_size_bits = 1024;
     let key_size_bytes = key_size_bits / 8;
@@ -333,7 +355,8 @@ fn key_body(request_method: Method) {
 #[test]
 fn status() {
     let client = common::build_client(&CONFIG.master_sae_crt);
-    let url = format!("{}/{}/status", CONFIG.base_url, CONFIG.slave_sae_id);
+    let url =
+        format!("{}/{}/status", CONFIG.base_server_url, CONFIG.slave_sae_id);
 
     let response = client.get(&url).send().unwrap();
     assert_eq!(response.status(), StatusCode::OK);


### PR DESCRIPTION
Adds a new environment variable : `ETSI_014_TEST_SUITE_BASE_CLIENT_URL`

Changes existing environment variable : `ETSI_014_TEST_SUITE_BASE_SERVER_URL` instead of `ETSI_014_TEST_SUITE_BASE_URL`

This makes it possible to test the ETSI in case the client and server are running on two separate instances, with a different url/port.

The default value provided in the Makefile have only been duplicated to avoid breaking existing code using this Makefile.

The README.md as well has been updated to reflect the changes.

The .gitignore has been update to avoid pushing IDE configuration.